### PR TITLE
Remove Error Module exports from src/index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,2 @@
 export { colors } from './console/builder';
 export { box } from './console/styles/box';
-
-// Error Module.
-export { ErrorCodes } from './utils/errors/ErrorCodes';
-export { Messages } from './utils/errors/Messages';
-export * from './utils/errors/KJS';


### PR DESCRIPTION
The Error Module exports have been removed to clean up the public API and prevent accidental usage. This change focuses the API surface on intended usage.

Fixes #4